### PR TITLE
Fix flatpak detection in install.sh.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # This script automatically detect the PulseEffects presets directory and installs the presets
 
 check_installation() {
-    if [[ $(flatpak list | grep -q "com.github.wwmm.pulseeffects") ]]; then
+    if flatpak list | grep -q "com.github.wwmm.pulseeffects"; then
         PRESETS_DIRECTORY="$HOME/.var/app/com.github.wwmm.pulseeffects/config/PulseEffects"
     elif [ -d "$HOME/.config/PulseEffects" ]; then
         PRESETS_DIRECTORY="$HOME/.config/PulseEffects"


### PR DESCRIPTION
Hi,
I've installed PulseEffects as a flatpak app from flathub.org using Gnome Software on Fedora 29. The check used in `install.sh` to detect flatpak installations doesn't work. To fix it I chose to keep the quiet flag of grep and evaluate greps exit code in the condition (0 = pattern found). Alternatively you could remove the quiet flag and use bash to check the string instead:
` if [[ $(flatpak list | grep "com.github.wwmm.pulseeffects") ]]; then echo flatpak: yes; else echo flatpak: no; fi`